### PR TITLE
Fix stanford type in mods config

### DIFF
--- a/mods_config.rb
+++ b/mods_config.rb
@@ -5,7 +5,6 @@ require 'dlme_json_resource_writer'
 require 'macros/dlme'
 require 'macros/mods'
 require 'macros/stanford'
-
 extend Macros::DLME
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Xml
@@ -59,7 +58,8 @@ to_field 'cho_description', extract_mods('/*/mods:location/mods:holdingSimple/mo
 to_field 'cho_description', extract_mods('/*/mods:note')
 to_field 'cho_description', extract_mods('/*/mods:physicalDescription/mods:note')
 to_field 'cho_description', extract_mods('/*/mods:tableOfContents')
-to_field 'cho_edm_type', normalize_type
+to_field 'cho_edm_type', extract_mods('/*/mods:typeOfResource[1]'),
+         strip, transform(&:downcase), translation_map('not_found', 'types', 'marc-types')
 to_field 'cho_extent', extract_mods('/*/mods:physicalDescription/mods:extent')
 to_field 'cho_format', extract_mods('/*/mods:physicalDescription/mods:form')
 to_field 'cho_has_part', generate_relation('/*/mods:relatedItem[@type="constituent"]')


### PR DESCRIPTION
No longer using `dlme-transform/lib/macros/mods.rb` to extract type. The type normalization logic has been updated, but `dlme-transform/lib/macros/mods.rb` has not. Opened https://github.com/sul-dlss/dlme-transform/issues/144 but not in scope for this work cycle. 