### PR TITLE
add missing extensions in metadata mappings via https://github.com/su…

### DIFF
--- a/metadata_mapping.json
+++ b/metadata_mapping.json
@@ -65,6 +65,7 @@
     "paths": [
       "penn/schoenberg"
     ],
+    "extension": ".xml",
     "settings": {
       "agg_provider": "University of Pennsylvania Libraries",
       "agg_data_provider": "University of Pennsylvania. Rare Book & Manuscript Library",
@@ -149,6 +150,7 @@
     "paths": [
       "harvard/maps"
     ],
+    "extension": ".xml",
     "settings": {
       "agg_provider": "Harvard University Library",
       "agg_data_provider": "Harvard University. Center for Geographic Analysis",


### PR DESCRIPTION
…l-dlss/dlme-traject/issues/123

## Why was this change made?
Found missing extensions on two data sets.

## Was the documentation (README, API, wiki, ...) updated?
Not applicable