### PR TITLE
changed name of tei_config to avoid future confusion; it only works f…

### DIFF
--- a/metadata_mapping.json
+++ b/metadata_mapping.json
@@ -60,20 +60,6 @@
   },
   {
     "trajects": [
-      "tei_config.rb"
-    ],
-    "paths": [
-      "penn/schoenberg"
-    ],
-    "extension": ".xml",
-    "settings": {
-      "agg_provider": "University of Pennsylvania Libraries",
-      "agg_data_provider": "University of Pennsylvania. Rare Book & Manuscript Library",
-      "inst_id": "penn"
-    }
-  },
-  {
-    "trajects": [
       "met_config.rb"
     ],
     "paths": [
@@ -272,7 +258,7 @@
   },
   {
     "trajects": [
-      "tei_config.rb"
+      "openn_config.rb"
     ],
     "paths": [
       "penn/openn/penn-0001",
@@ -287,7 +273,7 @@
   },
   {
     "trajects": [
-      "tei_config.rb"
+      "openn_config.rb"
     ],
     "paths": [
       "penn/openn/columbia-0032"
@@ -301,7 +287,7 @@
   },
   {
     "trajects": [
-      "tei_config.rb"
+      "openn_config.rb"
     ],
     "paths": [
       "penn/openn/free-library-philadelphia-0023"
@@ -315,7 +301,7 @@
   },
   {
     "trajects": [
-      "tei_config.rb"
+      "openn_config.rb"
     ],
     "paths": [
       "penn/openn/philadelphia-museum-art-0031"

--- a/openn_config.rb
+++ b/openn_config.rb
@@ -33,7 +33,7 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   accumulator << transform_values(context, 'wr_id' => [extract_tei("#{ms_desc}/#{ms_id}/tei:altIdentifier[@type='openn-url']/tei:idno")])
 end
 to_field 'agg_preview' do |_record, accumulator, context|
-  accumulator << transform_values(context, 'wr_id' => [penn_thumbnail])
+  accumulator << transform_values(context, 'wr_id' => [openn_thumbnail])
 end
 to_field 'cho_edm_type', literal('Text')
 


### PR DESCRIPTION
…or penn/openn data, updated metadata mapping

## Why was this change made?
To avoid misapplying the config file to other tei data; it only works for penn/openn data

## Was the documentation (README, API, wiki, ...) updated?
Not applicable