### PR TITLE
add new provider_country and data_provider_country fields to all configs

### DIFF
--- a/aims_config.rb
+++ b/aims_config.rb
@@ -43,3 +43,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_thumbnail, transform(&:to_s)]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/aub_common_config.rb
+++ b/aub_common_config.rb
@@ -48,3 +48,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   )
 end
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/auc_config.rb
+++ b/auc_config.rb
@@ -55,3 +55,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   )
 end
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/bnf_common_config.rb
+++ b/bnf_common_config.rb
@@ -47,3 +47,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_thumbnail, strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/bodleian_config.rb
+++ b/bodleian_config.rb
@@ -44,3 +44,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/cambridge_config.rb
+++ b/cambridge_config.rb
@@ -74,3 +74,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [extract_tei("#{facsimile}/tei:graphic/@url"), gsub('http://', 'https://image01.')])
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/cluster_config.rb
+++ b/cluster_config.rb
@@ -40,3 +40,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/csv_config.rb
+++ b/csv_config.rb
@@ -19,3 +19,6 @@ to_field 'cho_title', column('Object Name')
 # Aggregation Object(s)
 to_field 'agg_data_provider', data_provider
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/fgdc_config.rb
+++ b/fgdc_config.rb
@@ -87,6 +87,9 @@ to_field 'agg_is_shown_at' do |record, accumulator, context|
                                   'wr_dc_rights' => extract_fgdc('/*/idinfo/useconst'))
 end
 
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country
+
 # Not using agg_is_shown_at
 # Not using agg_is_shown_by
 # Not using agg_preview

--- a/harvard_ihp_config.rb
+++ b/harvard_ihp_config.rb
@@ -50,3 +50,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   )
 end
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/iiif_config.rb
+++ b/iiif_config.rb
@@ -21,3 +21,6 @@ to_field 'cho_title', extract_json('$.label')
 # Aggregation Object(s)
 to_field 'agg_data_provider', data_provider
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/marc_config.rb
+++ b/marc_config.rb
@@ -69,3 +69,6 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
   end
   accumulator << values
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/met_config.rb
+++ b/met_config.rb
@@ -62,3 +62,6 @@ to_field 'cho_spatial', extract_json('.subregion'), transform(&:presence)
 to_field 'cho_title', extract_json('.title')
 to_field 'cho_edm_type', edm_type
 to_field 'cho_type', literal('Image')
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/michigan_config.rb
+++ b/michigan_config.rb
@@ -65,3 +65,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   )
 end
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/mods_config.rb
+++ b/mods_config.rb
@@ -94,6 +94,9 @@ to_field 'cho_type', extract_mods('/*/mods:typeOfResource')
 to_field 'agg_data_provider', data_provider
 to_field 'agg_provider', provider
 
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country
+
 # agg_dc_rights:,
 # agg_edm_rights:,
 # agg_same_as

--- a/numismatic_csv_config.rb
+++ b/numismatic_csv_config.rb
@@ -56,3 +56,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
                                   'wr_id' => [column('Thumbnail_obv')])
 end
 to_field 'agg_provider', provider
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/openn_config.rb
+++ b/openn_config.rb
@@ -69,3 +69,6 @@ to_field 'agg_provider', provider
 to_field 'agg_data_provider', data_provider
 
 to_field 'agg_edm_rights', public_domain
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/penn_museum_config.rb
+++ b/penn_museum_config.rb
@@ -55,3 +55,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('thumbnail'), gsub('collections/assets/1600', 'collections/assets/300')])
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/pppa_config.rb
+++ b/pppa_config.rb
@@ -45,3 +45,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
   accumulator << transform_values(context,
                                   'wr_id' => [column('Thumbnail')])
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/princeton_movie_config.rb
+++ b/princeton_movie_config.rb
@@ -44,3 +44,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/princeton_mss_config.rb
+++ b/princeton_mss_config.rb
@@ -51,3 +51,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_json('.thumbnail'), strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/qnl_config.rb
+++ b/qnl_config.rb
@@ -41,3 +41,6 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
     'wr_id' => [extract_qnl('mods:location/mods:url'), strip]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/sakip_sabanci_config.rb
+++ b/sakip_sabanci_config.rb
@@ -52,3 +52,6 @@ to_field 'agg_preview' do |_record, accumulator, context|
     'wr_id' => [extract_cdm_preview]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/stanford_mods_config.rb
+++ b/stanford_mods_config.rb
@@ -66,3 +66,6 @@ end
 # STANFORD Specific
 to_field 'cho_type', extract_mods('/*/mods:extension/rdf:RDF/rdf:Description/dc:format')
 to_field 'cho_type', extract_mods('/*/mods:extension/rdf:RDF/rdf:Description/dc:type')
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country

--- a/yale_medical_config.rb
+++ b/yale_medical_config.rb
@@ -48,3 +48,6 @@ to_field 'agg_is_shown_at' do |_record, accumulator, context|
     'wr_id' => [column('Handle')]
   )
 end
+
+to_field 'agg_provider_country', provider_country
+to_field 'agg_data_provider_country', data_provider_country


### PR DESCRIPTION
## Why was this change made?

part of #111 -- uses new macro methods to fill in these fields (which will pull values from the metadata_mappings)

## Was the documentation (README, API, wiki, ...) updated?

will be in a separate PR as the documentation is in the dlme project
