### PR TITLE
Remove the provider country from plain mods

### DIFF
--- a/mods_config.rb
+++ b/mods_config.rb
@@ -95,9 +95,6 @@ to_field 'cho_type', extract_mods('/*/mods:typeOfResource')
 to_field 'agg_data_provider', data_provider
 to_field 'agg_provider', provider
 
-to_field 'agg_provider_country', provider_country
-to_field 'agg_data_provider_country', data_provider_country
-
 # agg_dc_rights:,
 # agg_edm_rights:,
 # agg_same_as


### PR DESCRIPTION
## Why was this change made?

Fixes #132, Part of https://github.com/sul-dlss/dlme-transform/issues/228, this removes the duplication of the `agg_data_provider_country` and `agg_provider_country`.

## Was the documentation (README, API, wiki, ...) updated?

N/A