### PR TITLE
Easy date parsing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,8 @@ AllCops:
 Metrics/LineLength:
   Max: 140
 
+Performance/StringReplacement:
+  Enabled: false
+
 Style/MixinUsage:
   Enabled: false

--- a/aims_config.rb
+++ b/aims_config.rb
@@ -3,9 +3,11 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
 require 'macros/aims'
 
 extend Macros::DLME
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend Macros::AIMS
 
@@ -21,7 +23,7 @@ to_field 'cho_title', extract_aims('title'), strip
 # CHO Other
 to_field 'cho_creator', extract_aims('author'), strip
 to_field 'cho_date', extract_aims('pubDate'), strip
-to_field 'cho_date_range_norm', extract_aims('pubDate'), strip
+to_field 'cho_date_range_norm', extract_aims('pubDate'), strip, single_year_from_string
 to_field 'cho_dc_rights', literal('Use of content for classroom purposes
                                   and on other non-profit educational websites is granted (and encouraged) with proper citation.')
 to_field 'cho_description', extract_aims('summary'), strip

--- a/aub_common_config.rb
+++ b/aub_common_config.rb
@@ -3,8 +3,11 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
 require 'macros/oai'
+
 extend Macros::DLME
+extend Macros::DateParsing
 extend Macros::OAI
 extend TrajectPlus::Macros
 
@@ -23,7 +26,7 @@ to_field 'cho_contributor', extract_oai('dc:contributor'),
 to_field 'cho_creator', extract_oai('dc:creator'),
          strip, split('.')
 to_field 'cho_date', extract_oai('dc:date'), strip
-to_field 'cho_date_range_norm', extract_oai('dc:date'), strip
+to_field 'cho_date_range_norm', extract_oai('dc:date'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_description', extract_oai('dc:description[2]'), strip
 to_field 'cho_dc_rights', extract_oai('dc:rights'), strip
 to_field 'cho_edm_type', extract_oai('dc:type'),

--- a/bnf_common_config.rb
+++ b/bnf_common_config.rb
@@ -3,9 +3,11 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
 require 'macros/srw'
 
 extend Macros::DLME
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend Macros::SRW
 
@@ -23,7 +25,7 @@ to_field 'cho_provenance', literal('This document is part of BnF website \'Bibli
 
 # Cho Other
 to_field 'cho_date', extract_srw('dc:date'), strip
-to_field 'cho_date_range_norm', extract_srw('dc:date'), strip
+to_field 'cho_date_range_norm', extract_srw('dc:date'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_description', extract_srw('dc:description'), strip
 to_field 'cho_dc_rights', extract_srw('dc:rights'), strip
 to_field 'cho_format', extract_srw('dc:format'), strip

--- a/cluster_config.rb
+++ b/cluster_config.rb
@@ -3,7 +3,10 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
+
 extend Macros::DLME
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -20,7 +23,7 @@ to_field 'cho_title', extract_json('.title'), strip
 to_field 'cho_creator', extract_json('.creator'), strip
 to_field 'cho_contributor', extract_json('.contributor'), strip
 to_field 'cho_date', extract_json('.date'), strip
-to_field 'cho_date_range_norm', extract_json('.date'), strip
+to_field 'cho_date_range_norm', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_edm_type', literal('Dataset')
 to_field 'cho_language', literal('English')

--- a/pppa_config.rb
+++ b/pppa_config.rb
@@ -3,9 +3,12 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
 require 'macros/csv'
+
 extend Macros::DLME
 extend Macros::Csv
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 
@@ -21,7 +24,7 @@ to_field 'cho_title', column('Title')
 # CHO Other
 to_field 'cho_creator', column('Creator')
 to_field 'cho_date', column('Date')
-to_field 'cho_date_range_norm', column('Date')
+to_field 'cho_date_range_norm', column('Date'), range_array_from_positive_4digits_hyphen
 to_field 'cho_description', column('Description')
 to_field 'cho_edm_type', literal('Image')
 to_field 'cho_identifier', column('Resource-URL')

--- a/princeton_movie_config.rb
+++ b/princeton_movie_config.rb
@@ -3,7 +3,10 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
+
 extend Macros::DLME
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -20,7 +23,7 @@ to_field 'cho_title', extract_json('.title'), strip
 to_field 'cho_contributor', extract_json('.director'), strip
 to_field 'cho_contributor', extract_json('.rendered_actors'), strip
 to_field 'cho_date', extract_json('.date_created'), strip
-to_field 'cho_date_range_norm', extract_json('.date_created'), strip
+to_field 'cho_date_range_norm', extract_json('.date_created'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services')
 to_field 'cho_description', extract_json('.member_of_collections'), strip
 to_field 'cho_edm_type', literal('Image')

--- a/princeton_mss_config.rb
+++ b/princeton_mss_config.rb
@@ -3,7 +3,10 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
+
 extend Macros::DLME
+extend Macros::DateParsing
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 
@@ -21,7 +24,7 @@ to_field 'cho_alternate', extract_json('.cho_alternate'), strip
 to_field 'cho_creator', extract_json('.author'), strip
 to_field 'cho_contributor', extract_json('.contributor'), strip
 to_field 'cho_date', extract_json('.date'), strip
-to_field 'cho_date_range_norm', extract_json('.date'), strip
+to_field 'cho_date_range_norm', extract_json('.date'), strip, range_array_from_positive_4digits_hyphen
 to_field 'cho_dc_rights', literal('https://rbsc.princeton.edu/services/imaging-publication-services')
 to_field 'cho_description', extract_json('.description'), strip
 to_field 'cho_description', extract_json('.contents'), strip

--- a/qnl_config.rb
+++ b/qnl_config.rb
@@ -3,11 +3,13 @@
 require 'traject_plus'
 require 'dlme_json_resource_writer'
 require 'macros/dlme'
+require 'macros/date_parsing'
 require 'macros/qnl'
 
 extend Macros::DLME
-extend Macros::QNL
+extend Macros::DateParsing
 extend TrajectPlus::Macros
+extend Macros::QNL
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
@@ -22,7 +24,8 @@ to_field 'cho_title', extract_qnl('mods:titleInfo/mods:title')
 to_field 'cho_coverage', extract_qnl('mods:subject/mods:geographic'), strip
 to_field 'cho_creator', extract_qnl('mods:name/mods:namePart'), strip
 to_field 'cho_date', extract_qnl('mods:originInfo/mods:dateIssued'), strip
-to_field 'cho_date_range_norm', extract_qnl('mods:originInfo/mods:dateIssued'), strip
+to_field 'cho_date_range_norm', extract_qnl('mods:originInfo/mods:dateIssued'),
+         strip, gsub('/', '-'), range_array_from_positive_4digits_hyphen
 to_field 'cho_dc_rights', literal('Open Government Licence')
 to_field 'cho_description', extract_qnl('mods:physicalDescription/mods:extent'), strip
 to_field 'cho_edm_type', extract_qnl('mods:typeOfResource'),


### PR DESCRIPTION
NOTE:  merge https://github.com/sul-dlss/dlme-transform/pull/231 first!

## Why was this change made?

DLME date slider needs a Solr field with an Array of integer years for the whole range.  The following collections will have properly populated `cho_date_range_norm` field, given PR sul-dlss/dlme-transform/pull/231:

- AIMS
- American University of Beirut
- British Library (qnl)
- CLUSTER
- IDEO, IFAO from BNF
- Palestine Poster Project Archive (pppa)
- Princeton (all colls, I believe - if that's what I got from Jacob for raw data examination)

These are the collections with the most straightforward date parsing, but we have to start somewhere.

## Was the documentation (README, API, wiki, ...) updated?

n/a
