### PR TITLE
penn_museum_config cho_date_range_norm uses DateParsing macro penn_museum_date_range

### DIFF
--- a/penn_museum_config.rb
+++ b/penn_museum_config.rb
@@ -2,15 +2,18 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
-require 'macros/dlme'
 require 'macros/csv'
-require 'macros/normalize'
+require 'macros/date_parsing'
+require 'macros/dlme'
+require 'macros/normalize_type'
 require 'macros/post_process'
 
-extend Macros::PostProcess
 extend Macros::DLME
 extend Macros::Csv
-extend Macros::Normalize
+extend Macros::DateParsing
+extend Macros::DLME
+extend Macros::NormalizeType
+extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::Csv
 


### PR DESCRIPTION
## Why was this change made?

To get clean date ranges from Penn Museum data for the date slider in the UI. This is the recset of issue sul-dlss/dlme-transform/issues/242.

## Was the documentation (README, API, wiki, ...) updated?

n/a