### PR TITLE
fgdc_config uses fgdc_date_range for cho_date_range_norm

### DIFF
--- a/fgdc_config.rb
+++ b/fgdc_config.rb
@@ -2,16 +2,18 @@
 
 require 'traject_plus'
 require 'dlme_json_resource_writer'
+require 'macros/date_parsing'
 require 'macros/dlme'
 require 'macros/fgdc'
 require 'macros/post_process'
 
-extend Macros::PostProcess
+extend Macros::DateParsing
 extend Macros::DLME
-extend TrajectPlus::Macros::Xml
 extend Macros::FGDC
+extend Macros::PostProcess
 extend TrajectPlus::Macros
 extend TrajectPlus::Macros::FGDC
+extend TrajectPlus::Macros::Xml
 
 settings do
   provide 'writer_class_name', 'DlmeJsonResourceWriter'
@@ -32,7 +34,7 @@ to_field 'cho_coverage', extract_fgdc('/*/dataqual/lineage/srcinfo/srctime/timei
 to_field 'cho_coverage', extract_fgdc('/*/dataqual/lineage/srcinfo/srctime/timeinfo/sngdate/caldate')
 # to_field 'cho_date', extract_fgdc('/*/dataqual/lineage/srcinfo/srccite/citeinfo/pubdate')
 to_field 'cho_date', extract_fgdc('/*/idinfo/citation/citeinfo/pubdate')
-to_field 'cho_date_range_norm', extract_fgdc('/*/idinfo/citation/citeinfo/pubdate')
+to_field 'cho_date_range_norm', fgdc_date_range
 # to_field 'cho_dc_rights', extract_fgdc('/*/idinfo/accconst')
 to_field 'cho_dc_rights', extract_fgdc('/*/idinfo/useconst')
 to_field 'cho_description', extract_fgdc('/*/idinfo/descript/abstract')


### PR DESCRIPTION
~~NOTE:  Do not merge before PR sul-dlss/dlme-transform/pull/254 is merged.~~

## Why was this change made?

To get clean date ranges from fgdc data (harvard/maps) for the date slider in the UI. This is part of   issue sul-dlss/dlme-transform/issues/183


## Was the documentation (README, API, wiki, ...) updated?

n/a